### PR TITLE
changes as per suggestions from PR#15

### DIFF
--- a/examples/DeepctrSVD.ipynb
+++ b/examples/DeepctrSVD.ipynb
@@ -1,0 +1,537 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DeepCTR's SVD"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "________________________"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "SVD is matrix factorization algorithm popularly used in recommedation system applications such as movie & product recommendation.\n",
+    "\n",
+    "This factorization technique is available for training & testing on recommendation datasets through libraries such as surpriselib which analytically does the factorization & produces decomposed matrices.\n",
+    "Whereas DeepCTR packages several FM techniques implemented through their DNN equivalents. Here one DeepCTR's method DeepFM is utilised to realise the implementation equivalence of SVD; Since the SVD results are here obtained through underlying Deep Neural Net, therefore DeepCTR's SVD."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**The following notebook serves as Usage guide**\n",
+    "_______________________________________________\n",
+    "* The SVD module requires passing feature_column value (which are nothing but `SparseFeat` instances for each input sparse feature) to obtain a tensorflow model.\n",
+    "* Towards the end, the obatained model is evaluating against sample test values."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1. Load sample dataset as pandas dataframe\n",
+    "___________________________________"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* List `sparse_features` & label encode input dataframe.\n",
+    "* Perform `train_test_split` to output training/test data and labels for model training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/kev/Desktop/pyvirtual2/lib/python3.6/site-packages/tensorflow/python/framework/dtypes.py:526: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
+      "  _np_qint8 = np.dtype([(\"qint8\", np.int8, 1)])\n",
+      "/home/kev/Desktop/pyvirtual2/lib/python3.6/site-packages/tensorflow/python/framework/dtypes.py:527: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
+      "  _np_quint8 = np.dtype([(\"quint8\", np.uint8, 1)])\n",
+      "/home/kev/Desktop/pyvirtual2/lib/python3.6/site-packages/tensorflow/python/framework/dtypes.py:528: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
+      "  _np_qint16 = np.dtype([(\"qint16\", np.int16, 1)])\n",
+      "/home/kev/Desktop/pyvirtual2/lib/python3.6/site-packages/tensorflow/python/framework/dtypes.py:529: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
+      "  _np_quint16 = np.dtype([(\"quint16\", np.uint16, 1)])\n",
+      "/home/kev/Desktop/pyvirtual2/lib/python3.6/site-packages/tensorflow/python/framework/dtypes.py:530: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
+      "  _np_qint32 = np.dtype([(\"qint32\", np.int32, 1)])\n",
+      "/home/kev/Desktop/pyvirtual2/lib/python3.6/site-packages/tensorflow/python/framework/dtypes.py:535: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.\n",
+      "  np_resource = np.dtype([(\"resource\", np.ubyte, 1)])\n",
+      "WARNING:root:\n",
+      "DeepCTR version 0.7.0 detected. Your version is 0.6.3.\n",
+      "Use `pip install -U deepctr` to upgrade.Changelog: https://github.com/shenweichen/DeepCTR/releases/tag/v0.7.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import pandas as pd\n",
+    "from sklearn.metrics import mean_squared_error\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.preprocessing import LabelEncoder\n",
+    "from deepctr.models import DeepFM\n",
+    "from deepctr.inputs import SparseFeat\n",
+    "\n",
+    "\n",
+    "data_path = os.path.expanduser('u.data')\n",
+    "df= pd.read_csv(data_path, sep='\\t',names= 'user_id,movie_id,rating,timestamp'.split(','))#, header=None)#used for DeepCTR"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* List **sparse features** from input dataframe\n",
+    "________________________________________________"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "feature names: ['user_id', 'movie_id'] \n",
+      "label name: ['rating']\n"
+     ]
+    }
+   ],
+   "source": [
+    "sparse_features = [\"user_id\", \"movie_id\"]\n",
+    "y= ['rating']\n",
+    "print('feature names:',sparse_features, '\\nlabel name:',y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    " * Label encoding features of input dataframe\n",
+    " __________________________________"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>user_id</th>\n",
+       "      <th>movie_id</th>\n",
+       "      <th>rating</th>\n",
+       "      <th>timestamp</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>0</td>\n",
+       "      <td>195</td>\n",
+       "      <td>241</td>\n",
+       "      <td>3</td>\n",
+       "      <td>881250949</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1</td>\n",
+       "      <td>185</td>\n",
+       "      <td>301</td>\n",
+       "      <td>3</td>\n",
+       "      <td>891717742</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>2</td>\n",
+       "      <td>21</td>\n",
+       "      <td>376</td>\n",
+       "      <td>1</td>\n",
+       "      <td>878887116</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   user_id  movie_id  rating  timestamp\n",
+       "0      195       241       3  881250949\n",
+       "1      185       301       3  891717742\n",
+       "2       21       376       1  878887116"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "for feat in sparse_features:\n",
+    "        lbe = LabelEncoder()\n",
+    "        df[feat] = lbe.fit_transform(df[feat])\n",
+    "        \n",
+    "df.head(3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Preparing training input data & target labels.**\n",
+    "_____________________________________________\n",
+    "* Training & test input data should be a list of numpy arrays of `user_ids` & `movie_ids`.\n",
+    "* Labels as numpy array of target values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train, test = train_test_split(df, test_size=0.2)\n",
+    "\n",
+    "train_model_input = [train[name].values for name in sparse_features]#includes values from only data[user_id], data[movie_id]\n",
+    "train_lbl = train[y].values\n",
+    "\n",
+    "test_model_input = [test[name].values for name in sparse_features]\n",
+    "test_lbl = test[y].values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "training data:\n",
+      " [array([415, 605, 739, ..., 845, 325, 515]), array([400, 759, 327, ..., 191, 674, 285])] \n",
+      "\n",
+      "training labels:\n",
+      " [[2]\n",
+      " [3]\n",
+      " [3]\n",
+      " ...\n",
+      " [5]\n",
+      " [4]\n",
+      " [5]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('training data:\\n', train_model_input, '\\n\\ntraining labels:\\n', train_lbl)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2. Obtain feature columns\n",
+    "________________________________________________\n",
+    "* Perform required data preparatory operations as described in DeepCtr docs (refer https://deepctr-doc.readthedocs.io/en/latest/Quick-Start.html).\n",
+    "\n",
+    "* Defining **feature columns** as list of SparseFeat instances for each sparse feature, here -- `user_id`, `movie_id`, by passing in `feature_name`, `num_unique feature vals` as arguments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[SparseFeat:user_id, SparseFeat:movie_id]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "feature_columns = [SparseFeat(feat, df[feat].nunique()) for feat in sparse_features]\n",
+    "feature_columns"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3. Import `SVD` from `mlsquare.layers.deepctr`\n",
+    "____________________________________________\n",
+    "* Instantiate the model.\n",
+    "* Train the model & evaluate results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Using TensorFlow backend.\n",
+      "2019-12-06 03:02:27,487\tINFO node.py:423 -- Process STDOUT and STDERR is being redirected to /tmp/ray/session_2019-12-06_03-02-27_10871/logs.\n",
+      "2019-12-06 03:02:27,598\tINFO services.py:363 -- Waiting for redis server at 127.0.0.1:44590 to respond...\n",
+      "2019-12-06 03:02:27,737\tINFO services.py:363 -- Waiting for redis server at 127.0.0.1:20042 to respond...\n",
+      "2019-12-06 03:02:27,746\tINFO services.py:760 -- Starting Redis shard with 20.0 GB max memory.\n",
+      "2019-12-06 03:02:27,793\tINFO services.py:1384 -- Starting the Plasma object store with 1.0 GB memory using /dev/shm.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from mlsquare.layers.deepctr import SVD"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* Now Instantiate the model by passing in args-- `feature_columns` & `embedding_size`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:From /home/kev/Desktop/pyvirtual2/lib/python3.6/site-packages/tensorflow/python/ops/resource_variable_ops.py:435: colocate_with (from tensorflow.python.framework.ops) is deprecated and will be removed in a future version.\n",
+      "Instructions for updating:\n",
+      "Colocations handled automatically by placer.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:From /home/kev/Desktop/pyvirtual2/lib/python3.6/site-packages/tensorflow/python/ops/resource_variable_ops.py:435: colocate_with (from tensorflow.python.framework.ops) is deprecated and will be removed in a future version.\n",
+      "Instructions for updating:\n",
+      "Colocations handled automatically by placer.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:From /home/kev/Desktop/pyvirtual2/lib/python3.6/site-packages/deepctr/layers/utils.py:156: calling reduce_sum_v1 (from tensorflow.python.ops.math_ops) with keep_dims is deprecated and will be removed in a future version.\n",
+      "Instructions for updating:\n",
+      "keep_dims is deprecated, use keepdims instead\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:From /home/kev/Desktop/pyvirtual2/lib/python3.6/site-packages/deepctr/layers/utils.py:156: calling reduce_sum_v1 (from tensorflow.python.ops.math_ops) with keep_dims is deprecated and will be removed in a future version.\n",
+      "Instructions for updating:\n",
+      "keep_dims is deprecated, use keepdims instead\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "__________________________________________________________________________________________________\n",
+      "Layer (type)                    Output Shape         Param #     Connected to                     \n",
+      "==================================================================================================\n",
+      "user_id (InputLayer)            (None, 1)            0                                            \n",
+      "__________________________________________________________________________________________________\n",
+      "movie_id (InputLayer)           (None, 1)            0                                            \n",
+      "__________________________________________________________________________________________________\n",
+      "sparse_emb_user_id (Embedding)  (None, 1, 100)       94300       user_id[0][0]                    \n",
+      "__________________________________________________________________________________________________\n",
+      "sparse_emb_movie_id (Embedding) (None, 1, 100)       168200      movie_id[0][0]                   \n",
+      "__________________________________________________________________________________________________\n",
+      "no_mask (NoMask)                (None, 1, 100)       0           sparse_emb_user_id[0][0]         \n",
+      "                                                                 sparse_emb_movie_id[0][0]        \n",
+      "__________________________________________________________________________________________________\n",
+      "concatenate (Concatenate)       (None, 2, 100)       0           no_mask[0][0]                    \n",
+      "                                                                 no_mask[1][0]                    \n",
+      "__________________________________________________________________________________________________\n",
+      "fm (FM)                         (None, 1)            0           concatenate[0][0]                \n",
+      "==================================================================================================\n",
+      "Total params: 262,500\n",
+      "Trainable params: 262,500\n",
+      "Non-trainable params: 0\n",
+      "__________________________________________________________________________________________________\n"
+     ]
+    }
+   ],
+   "source": [
+    "model = SVD(feature_columns, embedding_size=100)\n",
+    "model.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* Compile the model & fit on train data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:From /home/kev/Desktop/pyvirtual2/lib/python3.6/site-packages/tensorflow/python/keras/utils/losses_utils.py:170: to_float (from tensorflow.python.ops.math_ops) is deprecated and will be removed in a future version.\n",
+      "Instructions for updating:\n",
+      "Use tf.cast instead.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:From /home/kev/Desktop/pyvirtual2/lib/python3.6/site-packages/tensorflow/python/keras/utils/losses_utils.py:170: to_float (from tensorflow.python.ops.math_ops) is deprecated and will be removed in a future version.\n",
+      "Instructions for updating:\n",
+      "Use tf.cast instead.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Train on 64000 samples, validate on 16000 samples\n",
+      "WARNING:tensorflow:From /home/kev/Desktop/pyvirtual2/lib/python3.6/site-packages/tensorflow/python/ops/math_ops.py:3066: to_int32 (from tensorflow.python.ops.math_ops) is deprecated and will be removed in a future version.\n",
+      "Instructions for updating:\n",
+      "Use tf.cast instead.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:From /home/kev/Desktop/pyvirtual2/lib/python3.6/site-packages/tensorflow/python/ops/math_ops.py:3066: to_int32 (from tensorflow.python.ops.math_ops) is deprecated and will be removed in a future version.\n",
+      "Instructions for updating:\n",
+      "Use tf.cast instead.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1/8\n",
+      " - 3s - loss: 6.1732 - mean_squared_error: 6.1471 - val_loss: 1.5249 - val_mean_squared_error: 1.4720\n",
+      "Epoch 2/8\n",
+      " - 3s - loss: 1.1949 - mean_squared_error: 1.1329 - val_loss: 1.1028 - val_mean_squared_error: 1.0346\n",
+      "Epoch 3/8\n",
+      " - 3s - loss: 1.0318 - mean_squared_error: 0.9602 - val_loss: 1.0583 - val_mean_squared_error: 0.9840\n",
+      "Epoch 4/8\n",
+      " - 3s - loss: 1.0028 - mean_squared_error: 0.9270 - val_loss: 1.0338 - val_mean_squared_error: 0.9565\n",
+      "Epoch 5/8\n",
+      " - 3s - loss: 0.9831 - mean_squared_error: 0.9048 - val_loss: 1.0326 - val_mean_squared_error: 0.9534\n",
+      "Epoch 6/8\n",
+      " - 3s - loss: 0.9621 - mean_squared_error: 0.8818 - val_loss: 1.0174 - val_mean_squared_error: 0.9364\n",
+      "Epoch 7/8\n",
+      " - 3s - loss: 0.9319 - mean_squared_error: 0.8499 - val_loss: 1.0030 - val_mean_squared_error: 0.9197\n",
+      "Epoch 8/8\n",
+      " - 3s - loss: 0.8938 - mean_squared_error: 0.8097 - val_loss: 0.9979 - val_mean_squared_error: 0.9128\n"
+     ]
+    }
+   ],
+   "source": [
+    "model.compile(\"adam\", \"mse\", metrics=['mse'] )\n",
+    "history = model.fit(train_model_input, train_lbl, batch_size=64, epochs=8, verbose=2, validation_split=0.2,)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* Evaluating model prediction on test data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "For test user id: 822 & item id : 650 \n",
+      "True rating: [5] \n",
+      "Model prediction is: [4.842552]\n"
+     ]
+    }
+   ],
+   "source": [
+    "user_id = test_model_input[0][1]\n",
+    "item_id = test_model_input[1][1]\n",
+    "true_y= test[y].values[1]\n",
+    "print('For test user id: {} & item id : {} \\nTrue rating: {} \\nModel prediction is: {}'.format(user_id, item_id, true_y, model.predict(test_model_input)[1]))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/mlsquare/adapters/sklearn.py
+++ b/src/mlsquare/adapters/sklearn.py
@@ -6,8 +6,6 @@ from ..architectures import sklearn
 import pickle
 import onnxmltools
 import numpy as np
-
-import tensorflow as tf
   
     
 class SklearnKerasClassifier():
@@ -140,9 +138,6 @@ class SklearnKerasClassifier():
         print('Coming soon...')
         return self.final_model.summary()
 
-
-from mlsquare.architectures.sklearn import DimensionalityReductionModel
-
 class SklearnKerasRegressor():
     """
 	Adapter to connect sklearn regressor algorithms with keras models.
@@ -236,12 +231,12 @@ class SklearnKerasRegressor():
     
     def inverse_transform(self, X):
         if not isinstance(self.proxy_model, (sklearn.DimensionalityReductionModel)):
-            raise AttributeError("'SklearnKerasRegressor' object has no attribute 'inverse_transform'")        
-        return self.proxy_model.inverse_transform(X)    
+            raise AttributeError("'SklearnKerasRegressor' object has no attribute 'inverse_transform'")
+        return self.proxy_model.inverse_transform(X)
     
     def score(self, X, y, **kwargs):
         if isinstance(self.proxy_model, (sklearn.DimensionalityReductionModel)):
-            raise AttributeError("'SklearnKerasRegressor' object has no attribute 'score'")         
+            raise AttributeError("'SklearnKerasRegressor' object has no attribute 'score'")
         
         score = self.final_model.evaluate(X, y, **kwargs)
         return score
@@ -254,7 +249,6 @@ class SklearnKerasRegressor():
         '''
         if isinstance(self.proxy_model, (sklearn.DimensionalityReductionModel)):
             raise AttributeError("'SklearnKerasRegressor' object has no attribute 'predict'")
-            
         pred = self.final_model.predict(X)
         return pred
 

--- a/src/mlsquare/adapters/sklearn.py
+++ b/src/mlsquare/adapters/sklearn.py
@@ -7,7 +7,6 @@ import onnxmltools
 import numpy as np
 
 import tensorflow as tf
-from keras.utils import to_categorical
 
 class SklearnKerasDecompose():
     def __init__(self, proxy_model, primal_model, **kwargs):

--- a/src/mlsquare/adapters/sklearn.py
+++ b/src/mlsquare/adapters/sklearn.py
@@ -6,8 +6,8 @@ from ..architectures import sklearn
 import pickle
 import onnxmltools
 import numpy as np
-  
-    
+
+
 class SklearnKerasClassifier():
     """
 	Adapter to connect sklearn classifier algorithms with keras models.
@@ -199,7 +199,7 @@ class SklearnKerasRegressor():
                 raise TypeError("Params should be of type 'dict'")
             self.params = _parse_params(self.params, return_as='flat')
             self.proxy_model.update_params(self.params)
-        
+
         #if self.proxy_model.__class__.__name in ['SVD', 'PCA']:
         if isinstance(self.proxy_model, (sklearn.DimensionalityReductionModel)):
             return self.proxy_model.fit(X)
@@ -220,23 +220,24 @@ class SklearnKerasRegressor():
         if not isinstance(self.proxy_model, (sklearn.DimensionalityReductionModel)):
             raise AttributeError("'SklearnKerasRegressor' object has no attribute 'transform'")
         return self.proxy_model.transform(X)
-    
+
     def fit_transform(self, X,y=None):
         if not isinstance(self.proxy_model, (sklearn.DimensionalityReductionModel)):
             raise AttributeError("'SklearnKerasRegressor' object has no attribute 'fit_transform'")
         self.proxy_model.primal = self.primal_model
         return self.proxy_model.fit_transform(X)
-    
+
     def inverse_transform(self, X):
         if not isinstance(self.proxy_model, (sklearn.DimensionalityReductionModel)):
             raise AttributeError("'SklearnKerasRegressor' object has no attribute 'inverse_transform'")
         return self.proxy_model.inverse_transform(X)
-    
+
     def score(self, X, y, **kwargs):
         if isinstance(self.proxy_model, (sklearn.DimensionalityReductionModel)):
             raise AttributeError("'SklearnKerasRegressor' object has no attribute 'score'")
         score = self.final_model.evaluate(X, y, **kwargs)
         return score
+
     def predict(self, X):
         '''
         Pending:

--- a/src/mlsquare/adapters/sklearn.py
+++ b/src/mlsquare/adapters/sklearn.py
@@ -240,7 +240,7 @@ class SklearnKerasRegressor():
         
         score = self.final_model.evaluate(X, y, **kwargs)
         return score
-    
+        
     def predict(self, X):
         '''
         Pending:

--- a/src/mlsquare/adapters/sklearn.py
+++ b/src/mlsquare/adapters/sklearn.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 from ..optmizers import get_best_model
 from ..utils.functions import _parse_params
-from ..architectures import sklearn
 import pickle
 import onnxmltools
 import numpy as np
@@ -59,7 +58,7 @@ class SklearnTfTransformer():
             self.params = _parse_params(self.params, return_as='flat')
             self.proxy_model.update_params(self.params)
 
-        self.fit_transform(X)
+        self.proxy_model.fit(X)
 
         self.params = self.proxy_model.get_params()
         #to avoid calling model.fit(X).proxy_model for sigma & Vh
@@ -282,8 +281,6 @@ class SklearnKerasRegressor():
         return self.final_model  # Not necessary.
 
     def score(self, X, y, **kwargs):
-        if isinstance(self.proxy_model, (sklearn.DimensionalityReductionModel)):
-            raise AttributeError("'SklearnKerasRegressor' object has no attribute 'score'")
         score = self.final_model.evaluate(X, y, **kwargs)
         return score
 
@@ -293,8 +290,6 @@ class SklearnKerasRegressor():
         1) Write a 'filter_sk_params' function(check keras_regressor wrapper) if necessary.
         2) Data checks and data conversions
         '''
-        if isinstance(self.proxy_model, (sklearn.DimensionalityReductionModel)):
-            raise AttributeError("'SklearnKerasRegressor' object has no attribute 'predict'")
         pred = self.final_model.predict(X)
         return pred
 
@@ -302,8 +297,6 @@ class SklearnKerasRegressor():
         if filename == None:
             raise ValueError(
                 'Name Error: to save the model you need to specify the filename')
-        if isinstance(self.proxy_model, (sklearn.DimensionalityReductionModel)):
-            raise AttributeError("'SklearnKerasRegressor' object has no attribute 'save'")
         pickle.dump(self.final_model, open(filename + '.pkl', 'wb'))
 
         self.final_model.save(filename + '.h5')

--- a/src/mlsquare/adapters/sklearn.py
+++ b/src/mlsquare/adapters/sklearn.py
@@ -2,63 +2,13 @@
 # -*- coding: utf-8 -*-
 from ..optmizers import get_best_model
 from ..utils.functions import _parse_params
+from ..architectures import sklearn
 import pickle
 import onnxmltools
 import numpy as np
 
 import tensorflow as tf
-
-class SklearnKerasDecompose():
-    def __init__(self, proxy_model, primal_model, **kwargs):
-        self.primal_model = primal_model
-        self.params = None ## Temporary!
-        self.proxy_model = proxy_model
-        self.n_components= primal_model.n_components#moved here so user like in sklearncan can access n_components, even before .fit_transform. 
-        
-    def fit(self, X, y=None, **kwargs):
-        self.fit_transform(X)
-        return self
-    
-    def fit_transform(self, X, y=None,**kwargs):
-        kwargs.setdefault('full_matrices', False)
-        kwargs.setdefault('params', self.params)
-        kwargs.setdefault('space', False)
-        kwargs.setdefault('compute_uv', True)
-        kwargs.setdefault('name', None)
-        self.params = kwargs['params']
-        X = np.array(X)
-        y = np.array(y)
-        
-        #primal_model = self.primal_model
-        #self.proxy_model.n_components= primal_model.n_components        
-        #self.n_components= primal_model.n_components # Now its callable as model.num_components just like a sklearn svd object
-        
-        #?--should the `.num_components`, '.components_', '.singular_values_' be defined as attributes of proxy_model class or adapter class --?
-        
-        k = self.n_components
-        n_features = X.shape[1]
-        if k>= n_features:
-                raise ValueError("n_components must be < n_features;"
-                                 " got %d >= %d" % (k, n_features))
-            
-        sess= tf.Session()#for TF  1.13
-        s,u,v= sess.run(tf.linalg.svd(X, full_matrices=kwargs['full_matrices'], compute_uv=kwargs['compute_uv']))#for TF  1.13
-        #s: singular values
-        #u: normalised projection distances
-        #v: decomposition/projection orthogonal axes
-        
-        self.components_= v[:self.n_components,:]
-        #self.proxy_model.components_= v[:self.proxy_model.n_components,:]#analogous to TruncatedSVD().components_ Or primal_model.components_ Or Vh component from randomised SVD
-        
-        #Sigma = s[:self.proxy_model.num_components]
-        X_transformed = u[:,:self.n_components] * s[:self.n_components]
-        #X_transformed = u[:,:self.proxy_model.n_components] * s[:self.proxy_model.n_components]
-        
-        self.singular_values_ = s[:self.n_components]
-        #self.proxy_model.singular_values_ = s[:self.proxy_model.n_components]# Store the n_components singular values
-        
-        return X_transformed
-    
+  
     
 class SklearnKerasClassifier():
     """
@@ -191,6 +141,7 @@ class SklearnKerasClassifier():
         return self.final_model.summary()
 
 
+from mlsquare.architectures.sklearn import DimensionalityReductionModel
 
 class SklearnKerasRegressor():
     """
@@ -238,7 +189,7 @@ class SklearnKerasRegressor():
         self.proxy_model = proxy_model
         self.params = None
 
-    def fit(self, X, y, **kwargs):
+    def fit(self, X, y=None, **kwargs):
         self.proxy_model.X = X
         self.proxy_model.y = y
         self.proxy_model.primal = self.primal_model
@@ -253,6 +204,11 @@ class SklearnKerasRegressor():
                 raise TypeError("Params should be of type 'dict'")
             self.params = _parse_params(self.params, return_as='flat')
             self.proxy_model.update_params(self.params)
+            
+        #if self.proxy_model.__class__.__name in ['SVD', 'PCA']:
+        if isinstance(self.proxy_model, (sklearn.DimensionalityReductionModel)):
+            return self.proxy_model.fit(X)
+        
         primal_model = self.primal_model
         primal_model.fit(X, y)
         y_pred = primal_model.predict(X)
@@ -266,16 +222,39 @@ class SklearnKerasRegressor():
                                           verbose=kwargs['verbose'])
         return self.final_model  # Not necessary.
 
+    def transform(self, X):
+        if not isinstance(self.proxy_model, (sklearn.DimensionalityReductionModel)):
+            raise AttributeError("'SklearnKerasRegressor' object has no attribute 'transform'")
+        return self.proxy_model.transform(X)
+    
+    def fit_transform(self, X,y=None):
+        if not isinstance(self.proxy_model, (sklearn.DimensionalityReductionModel)):
+            raise AttributeError("'SklearnKerasRegressor' object has no attribute 'fit_transform'")
+        
+        self.proxy_model.primal = self.primal_model
+        return self.proxy_model.fit_transform(X)
+    
+    def inverse_transform(self, X):
+        if not isinstance(self.proxy_model, (sklearn.DimensionalityReductionModel)):
+            raise AttributeError("'SklearnKerasRegressor' object has no attribute 'inverse_transform'")        
+        return self.proxy_model.inverse_transform(X)    
+    
     def score(self, X, y, **kwargs):
+        if isinstance(self.proxy_model, (sklearn.DimensionalityReductionModel)):
+            raise AttributeError("'SklearnKerasRegressor' object has no attribute 'score'")         
+        
         score = self.final_model.evaluate(X, y, **kwargs)
         return score
-
+    
     def predict(self, X):
         '''
         Pending:
         1) Write a 'filter_sk_params' function(check keras_regressor wrapper) if necessary.
         2) Data checks and data conversions
         '''
+        if isinstance(self.proxy_model, (sklearn.DimensionalityReductionModel)):
+            raise AttributeError("'SklearnKerasRegressor' object has no attribute 'predict'")
+            
         pred = self.final_model.predict(X)
         return pred
 
@@ -284,6 +263,8 @@ class SklearnKerasRegressor():
             raise ValueError(
                 'Name Error: to save the model you need to specify the filename')
 
+        if isinstance(self.proxy_model, (sklearn.DimensionalityReductionModel)):
+            raise AttributeError("'SklearnKerasRegressor' object has no attribute 'save'")
         pickle.dump(self.final_model, open(filename + '.pkl', 'wb'))
 
         self.final_model.save(filename + '.h5')

--- a/src/mlsquare/adapters/sklearn.py
+++ b/src/mlsquare/adapters/sklearn.py
@@ -47,7 +47,6 @@ class SklearnTfTransformer():
         self.primal_model = primal_model
         self.proxy_model = proxy_model
         self.proxy_model.primal = self.primal_model
-        #self.proxy_model(primal_model)#to access proxy_model.n_components
         self.params = None
 
     def fit(self, X, y=None, **kwargs):
@@ -60,30 +59,21 @@ class SklearnTfTransformer():
             self.params = _parse_params(self.params, return_as='flat')
             self.proxy_model.update_params(self.params)
 
-        #if self.proxy_model.__class__.__name in ['SVD', 'PCA']:
-        if isinstance(self.proxy_model, (sklearn.DimensionalityReductionModel)):
-            self.fit_transform(X)
+        self.fit_transform(X)
 
-            self.params = self.proxy_model.get_params()
-            #to avoid calling model.fit(X).proxy_model for sigma & Vh
-            self.components_= self.params['components_']
-            self.singular_values_= self.params['singular_values_']
-            return self
+        self.params = self.proxy_model.get_params()
+        #to avoid calling model.fit(X).proxy_model for sigma & Vh
+        self.components_= self.params['components_']
+        self.singular_values_= self.params['singular_values_']
+        return self
 
     def transform(self, X):
-        if not isinstance(self.proxy_model, (sklearn.DimensionalityReductionModel)):
-            raise AttributeError("'SklearnTfTransformer' object has no attribute 'transform'")
         return self.proxy_model.transform(X)
 
     def fit_transform(self, X,y=None):
-        if not isinstance(self.proxy_model, (sklearn.DimensionalityReductionModel)):
-            raise AttributeError("'SklearnTfTransformer' object has no attribute 'fit_transform'")
-        self.proxy_model.primal = self.primal_model
         return self.proxy_model.fit_transform(X)
 
     def inverse_transform(self, X):
-        if not isinstance(self.proxy_model, (sklearn.DimensionalityReductionModel)):
-            raise AttributeError("'SklearnTfTransformer' object has no attribute 'inverse_transform'")
         return self.proxy_model.inverse_transform(X)
 
 

--- a/src/mlsquare/adapters/sklearn.py
+++ b/src/mlsquare/adapters/sklearn.py
@@ -240,7 +240,6 @@ class SklearnKerasRegressor():
         
         score = self.final_model.evaluate(X, y, **kwargs)
         return score
-        
     def predict(self, X):
         '''
         Pending:

--- a/src/mlsquare/adapters/sklearn.py
+++ b/src/mlsquare/adapters/sklearn.py
@@ -199,11 +199,10 @@ class SklearnKerasRegressor():
                 raise TypeError("Params should be of type 'dict'")
             self.params = _parse_params(self.params, return_as='flat')
             self.proxy_model.update_params(self.params)
-            
+        
         #if self.proxy_model.__class__.__name in ['SVD', 'PCA']:
         if isinstance(self.proxy_model, (sklearn.DimensionalityReductionModel)):
             return self.proxy_model.fit(X)
-        
         primal_model = self.primal_model
         primal_model.fit(X, y)
         y_pred = primal_model.predict(X)
@@ -225,7 +224,6 @@ class SklearnKerasRegressor():
     def fit_transform(self, X,y=None):
         if not isinstance(self.proxy_model, (sklearn.DimensionalityReductionModel)):
             raise AttributeError("'SklearnKerasRegressor' object has no attribute 'fit_transform'")
-        
         self.proxy_model.primal = self.primal_model
         return self.proxy_model.fit_transform(X)
     
@@ -237,7 +235,6 @@ class SklearnKerasRegressor():
     def score(self, X, y, **kwargs):
         if isinstance(self.proxy_model, (sklearn.DimensionalityReductionModel)):
             raise AttributeError("'SklearnKerasRegressor' object has no attribute 'score'")
-        
         score = self.final_model.evaluate(X, y, **kwargs)
         return score
     def predict(self, X):
@@ -255,7 +252,6 @@ class SklearnKerasRegressor():
         if filename == None:
             raise ValueError(
                 'Name Error: to save the model you need to specify the filename')
-
         if isinstance(self.proxy_model, (sklearn.DimensionalityReductionModel)):
             raise AttributeError("'SklearnKerasRegressor' object has no attribute 'save'")
         pickle.dump(self.final_model, open(filename + '.pkl', 'wb'))

--- a/src/mlsquare/architectures/sklearn.py
+++ b/src/mlsquare/architectures/sklearn.py
@@ -111,7 +111,7 @@ class DimensionalityReductionModel:
         """Needs Implementation in sub classes"""
         
     @abstractmethod
-    def fit_transform(self, X, y=None, **kwargs)):
+    def fit_transform(self, X, y=None, **kwargs):
         """Needs Implementation in sub classes"""
 
 @registry.register
@@ -121,9 +121,7 @@ class SVD(DimensionalityReductionModel, GeneralizedLinearModel):
         self.module_name = 'sklearn'
         self.name = 'TruncatedSVD'
         self.version = 'default'
-        model_params = {'full_matrices': False,
-                       'compute_uv': True,
-                      'name':None}
+        model_params = {'full_matrices': False, 'compute_uv': True, 'name':None}
         self.set_params(params=model_params, set_by='model_init')
     
     def fit(self, X, y=None, **kwargs):

--- a/src/mlsquare/architectures/sklearn.py
+++ b/src/mlsquare/architectures/sklearn.py
@@ -7,7 +7,7 @@ import numpy as np
 from keras.models import Model
 from sklearn.preprocessing import OneHotEncoder
 from ..base import registry, BaseModel
-from ..adapters.sklearn import SklearnKerasClassifier, SklearnKerasRegressor, SklearnPytorchClassifier, SklearnKerasDecompose, SklearnKerasDecompose_1
+from ..adapters.sklearn import SklearnKerasClassifier, SklearnKerasRegressor, SklearnPytorchClassifier, SklearnKerasDecompose
 from ..layers.keras import DecisionTree
 from ..utils.functions import _parse_params
 # from ..losses import lda_loss

--- a/src/mlsquare/architectures/sklearn.py
+++ b/src/mlsquare/architectures/sklearn.py
@@ -15,86 +15,6 @@ import pandas
 from abc import abstractmethod
 # from ..losses import lda_loss
 
-class DimensionalityReductionModel:
-    """
-	A base class for all matrix decomposition models.
-
-    This class can be used as a base class for any dimensionality reduction models.
-    While implementing ensure all required methods are implemented or over written
-    Please refer to sklearn decomposition module for more details.
-
-    Methods
-    -------
-	fit(input_args)
-        fits the model to output singular decomposed values.
-        But outputs an object to further transform.
-
-	fir_transform(input_args)
-        fits the model to output input values with reduced dimensions.
-	
-
-    """
-    @abstractmethod
-    def fit(self, X, y= None):
-        """Needs Implementation in sub classes"""
-        
-    @abstractmethod
-    def fit_transform(self, X, y=None):
-        """Needs Implementation in sub classes"""
-
-@registry.register
-class SVD(DimensionalityReductionModel, GeneralizedLinearModel):
-    def __init__(self):
-        self.adapter = SklearnKerasRegressor
-        self.module_name = 'sklearn' 
-        self.name = 'TruncatedSVD'
-        self.version = 'default'
-        model_params = {'full_matrices': False,
-                       'compute_uv': True,
-                      'name':None}
-        self.set_params(params=model_params, set_by='model_init')
-    
-    def fit(self, X, y=None, **kwargs):
-        self.fit_transform(X)
-        return self
-    
-    def fit_transform(self, X, y=None,**kwargs):
-        kwargs.setdefault('full_matrices', False)
-        kwargs.setdefault('compute_uv', True)
-        kwargs.setdefault('name', None)
-        
-        X = np.array(X, dtype= np.float32 if str(X.values.dtype)=='float32' else np.float64) if isinstance(X, pandas.core.frame.DataFrame) else np.array(X, dtype= np.float32 if str(X.dtype)=='float32' else np.float64)#changing to recommended dtype, accomodating dataframe & numpy array
-       
-        n_components= self.primal.n_components#using primal attributes passed from adapter
-        n_features = X.shape[1]
-
-        if n_components>= n_features:
-                raise ValueError("n_components must be < n_features;"
-                                 " got %d >= %d" % (n_components, n_features))
-                
-        sess= tf.Session()#for TF  1.13
-        s,u,v= sess.run(tf.linalg.svd(X, full_matrices=kwargs['full_matrices'], compute_uv=kwargs['compute_uv']))#for TF  1.13
-        #s: singular values
-        #u: normalised projection distances
-        #v: decomposition/projection orthogonal axes
-        
-        self.components_= v[:n_components,:]
-        X_transformed = u[:,:n_components] * s[:n_components]
-        
-        self.explained_variance_= np.var(X_transformed, axis=0)        
-        self.singular_values_ = s[:n_components]
-
-        return X_transformed
-    
-    def transform(self, X):
-        components= self.components_.T 
-        return X@components
-    
-    def inverse_transform(self, X):
-        return np.dot(X, self.components_)
-
-
-
 class GeneralizedLinearModel(BaseModel):
     """
 	A base class for all generalized linear models.
@@ -166,6 +86,86 @@ class GeneralizedLinearModel(BaseModel):
 
     def adapter(self):
         return self._adapter
+
+class DimensionalityReductionModel:
+    """
+	A base class for all matrix decomposition models.
+
+    This class can be used as a base class for any dimensionality reduction models.
+    While implementing ensure all required methods are implemented or over written
+    Please refer to sklearn decomposition module for more details.
+
+    Methods
+    -------
+	fit(input_args)
+        fits the model to output singular decomposed values.
+        But outputs an object to further transform.
+
+	fir_transform(input_args)
+        fits the model to output input values with reduced dimensions.
+	
+
+    """
+    @abstractmethod
+    def fit(self, X, y= None, **kwargs)):
+        """Needs Implementation in sub classes"""
+        
+    @abstractmethod
+    def fit_transform(self, X, y=None, **kwargs)):
+        """Needs Implementation in sub classes"""
+
+@registry.register
+class SVD(DimensionalityReductionModel, GeneralizedLinearModel):
+    def __init__(self):
+        self.adapter = SklearnKerasRegressor
+        self.module_name = 'sklearn'
+        self.name = 'TruncatedSVD'
+        self.version = 'default'
+        model_params = {'full_matrices': False,
+                       'compute_uv': True,
+                      'name':None}
+        self.set_params(params=model_params, set_by='model_init')
+    
+    def fit(self, X, y=None, **kwargs):
+        self.fit_transform(X)
+        return self
+    
+    def fit_transform(self, X, y=None,**kwargs):
+        kwargs.setdefault('full_matrices', False)
+        kwargs.setdefault('compute_uv', True)
+        kwargs.setdefault('name', None)
+        
+        X = np.array(X, dtype= np.float32 if str(X.values.dtype)==
+        'float32' else np.float64) if isinstance(X,
+        pandas.core.frame.DataFrame) else np.array(X, dtype= np.float32 
+        if str(X.dtype)=='float32' else np.float64)#changing to recommended dtype, accomodating dataframe & numpy array
+       
+        n_components= self.primal.n_components#using primal attributes passed from adapter
+        n_features = X.shape[1]
+
+        if n_components>= n_features:
+                raise ValueError("n_components must be < n_features;"
+                                 " got %d >= %d" % (n_components, n_features))
+                
+        sess= tf.Session()#for TF  1.13
+        s,u,v= sess.run(tf.linalg.svd(X, full_matrices=kwargs['full_matrices'], compute_uv=kwargs['compute_uv']))#for TF  1.13
+        #s: singular values
+        #u: normalised projection distances
+        #v: decomposition/projection orthogonal axes
+        
+        self.components_= v[:n_components,:]
+        X_transformed = u[:,:n_components] * s[:n_components]
+        
+        self.explained_variance_= np.var(X_transformed, axis=0)
+        self.singular_values_ = s[:n_components]
+
+        return X_transformed
+    
+    def transform(self, X):
+        return np.dot(X, self.components_.T)
+    
+    def inverse_transform(self, X):
+        return np.dot(X, self.components_)
 
 @registry.register
 class LogisticRegression(GeneralizedLinearModel):

--- a/src/mlsquare/architectures/sklearn.py
+++ b/src/mlsquare/architectures/sklearn.py
@@ -107,7 +107,7 @@ class DimensionalityReductionModel:
 
     """
     @abstractmethod
-    def fit(self, X, y= None, **kwargs)):
+    def fit(self, X, y= None, **kwargs):
         """Needs Implementation in sub classes"""
         
     @abstractmethod
@@ -175,9 +175,9 @@ class LogisticRegression(GeneralizedLinearModel):
         self.name = 'LogisticRegression'
         self.version = 'default'
         model_params = {'layer_1': {'units': 1, ## Make key name private - '_layer'
-                                    'l1': 0,
-                                    'l2': 0,
-                                    'activation': 'sigmoid'},
+                        'l1': 0,
+                        'l2': 0,
+                        'activation': 'sigmoid'},
                         'optimizer': 'adam',
                         'loss': 'binary_crossentropy'
                         }

--- a/src/mlsquare/architectures/sklearn.py
+++ b/src/mlsquare/architectures/sklearn.py
@@ -87,7 +87,7 @@ class GeneralizedLinearModel(BaseModel):
     def adapter(self):
         return self._adapter
 
-class MatrixDecomposition:
+class MatrixDecomposition(BaseTransformer):
     """
 	A base class for all matrix decomposition models.
 
@@ -106,6 +106,12 @@ class MatrixDecomposition:
 	update_params(params)
         Method to update params.
     """
+    def fit(X, y, **kwargs):
+        pass
+
+    def fit_transform(X, y, **kwargs):
+        pass
+
     def set_params(self, **kwargs):
         kwargs.setdefault('params', None)
         self._model_params = _parse_params(kwargs['params'], return_as='flat')
@@ -117,7 +123,7 @@ class MatrixDecomposition:
         self._model_params.update(params)
 
 @registry.register
-class SVD(BaseTransformer, MatrixDecomposition):
+class SVD(MatrixDecomposition):
     def __init__(self):
         self.adapter = SklearnTfTransformer
         self.module_name = 'sklearn'
@@ -125,6 +131,10 @@ class SVD(BaseTransformer, MatrixDecomposition):
         self.version = 'default'
         model_params = {'full_matrices': False, 'compute_uv': True, 'name':None}
         self.set_params(params=model_params)
+
+    def fit(self, X, y=None,**kwargs):
+        self.fit_transform(X)
+        return self
 
     def fit_transform(self, X, y=None,**kwargs):
         model_params= _parse_params(self._model_params, return_as='flat')

--- a/src/mlsquare/architectures/sklearn.py
+++ b/src/mlsquare/architectures/sklearn.py
@@ -7,7 +7,7 @@ import numpy as np
 from keras.models import Model
 from sklearn.preprocessing import OneHotEncoder
 from ..base import registry, BaseModel
-from ..adapters.sklearn import SklearnKerasClassifier, SklearnKerasRegressor, SklearnPytorchClassifier
+from ..adapters.sklearn import SklearnKerasClassifier, SklearnKerasRegressor, SklearnPytorchClassifier, SklearnKerasDecompose, SklearnKerasDecompose_1
 from ..layers.keras import DecisionTree
 from ..utils.functions import _parse_params
 # from ..losses import lda_loss
@@ -85,6 +85,22 @@ class GeneralizedLinearModel(BaseModel):
     def adapter(self):
         return self._adapter
 
+            
+@registry.register
+class SVD(GeneralizedLinearModel):
+    def __init__(self):
+        self.adapter = SklearnKerasDecompose
+        self.module_name = 'sklearn' 
+        self.name = 'TruncatedSVD'
+        self.version = 'default'
+        model_params = {'full_matrices': False,
+                       'compute_uv': True,
+                      'name':None}
+
+        self.set_params(params=model_params, set_by='model_init')
+    def create_model(self, **kwargs):
+        pass
+    
 
 @registry.register
 class LogisticRegression(GeneralizedLinearModel):
@@ -372,3 +388,6 @@ class DecisionTreeClassifier(CART):
         }
 
         self.set_params(params=model_params, set_by='model_init')
+
+
+

--- a/src/mlsquare/architectures/sklearn.py
+++ b/src/mlsquare/architectures/sklearn.py
@@ -109,7 +109,7 @@ class DimensionalityReductionModel:
     @abstractmethod
     def fit(self, X, y= None, **kwargs):
         """Needs Implementation in sub classes"""
-        
+
     @abstractmethod
     def fit_transform(self, X, y=None, **kwargs):
         """Needs Implementation in sub classes"""
@@ -123,37 +123,37 @@ class SVD(DimensionalityReductionModel, GeneralizedLinearModel):
         self.version = 'default'
         model_params = {'full_matrices': False, 'compute_uv': True, 'name':None}
         self.set_params(params=model_params, set_by='model_init')
-    
+
     def fit(self, X, y=None, **kwargs):
         self.fit_transform(X)
         return self
-    
+
     def fit_transform(self, X, y=None,**kwargs):
         kwargs.setdefault('full_matrices', False)
         kwargs.setdefault('compute_uv', True)
         kwargs.setdefault('name', None)
-        
+
         X = np.array(X, dtype= np.float32 if str(X.values.dtype)==
         'float32' else np.float64) if isinstance(X,
-        pandas.core.frame.DataFrame) else np.array(X, dtype= np.float32 
+        pandas.core.frame.DataFrame) else np.array(X, dtype= np.float32
         if str(X.dtype)=='float32' else np.float64)#changing to recommended dtype, accomodating dataframe & numpy array
-       
+
         n_components= self.primal.n_components#using primal attributes passed from adapter
         n_features = X.shape[1]
 
         if n_components>= n_features:
                 raise ValueError("n_components must be < n_features;"
                                  " got %d >= %d" % (n_components, n_features))
-                
+
         sess= tf.Session()#for TF  1.13
         s,u,v= sess.run(tf.linalg.svd(X, full_matrices=kwargs['full_matrices'], compute_uv=kwargs['compute_uv']))#for TF  1.13
         #s: singular values
         #u: normalised projection distances
         #v: decomposition/projection orthogonal axes
-        
+
         self.components_= v[:n_components,:]
         X_transformed = u[:,:n_components] * s[:n_components]
-        
+
         self.explained_variance_= np.var(X_transformed, axis=0)
         self.singular_values_ = s[:n_components]
 
@@ -161,7 +161,7 @@ class SVD(DimensionalityReductionModel, GeneralizedLinearModel):
     
     def transform(self, X):
         return np.dot(X, self.components_.T)
-    
+
     def inverse_transform(self, X):
         return np.dot(X, self.components_)
 

--- a/src/mlsquare/architectures/sklearn.py
+++ b/src/mlsquare/architectures/sklearn.py
@@ -158,7 +158,7 @@ class SVD(DimensionalityReductionModel, GeneralizedLinearModel):
         self.singular_values_ = s[:n_components]
 
         return X_transformed
-    
+
     def transform(self, X):
         return np.dot(X, self.components_.T)
 

--- a/src/mlsquare/base.py
+++ b/src/mlsquare/base.py
@@ -103,4 +103,21 @@ class BaseModel(ABC):
 	def transform_data(self, X, y, y_pred):
 		return X, y, y_pred
 
+class BaseTransformer(ABC):
+    """
+	A base class for matrix decomposition models.
+
+    This class can be used as a base class for any dimensionality reduction models.
+    While implementing ensure all required methods are implemented or over written
+    Please refer to sklearn decomposition module for more details.
+
+    Methods
+    -------
+	fir_transform(input_args)
+        fits the model to output input values with reduced dimensions.
+    """
+    @abstractmethod
+    def fit_transform(self, X, y=None, **kwargs):
+        raise NotImplementedError('Needs to be implemented!')
+
 registry = Registry()

--- a/src/mlsquare/layers/__init__.py
+++ b/src/mlsquare/layers/__init__.py
@@ -1,1 +1,2 @@
 from .keras import DecisionTree, Bin, KronProd
+from .deepctr import SVD

--- a/src/mlsquare/layers/deepctr.py
+++ b/src/mlsquare/layers/deepctr.py
@@ -1,0 +1,36 @@
+# -*- coding:utf-8 -*-
+import tensorflow as tf
+from deepctr.inputs import build_input_features, input_from_feature_columns
+
+from deepctr.layers.interaction import FM
+from deepctr.layers.utils import concat_fun
+
+
+def SVD(feature_columns, embedding_size=100,
+        l2_reg_embedding=1e-5, l2_reg_linear=1e-5, l2_reg_dnn=0, init_std=0.0001, seed=1024, bi_dropout=0,
+        dnn_dropout=0):
+    """Instantiates the Neural Factorization Machine architecture.
+
+    :param feature_columns: An iterable containing all the sparse features used by model.
+    :param num_factors: number of units in latent representation layer.
+    :param l2_reg_embedding: float. L2 regularizer strength applied to embedding vector
+    :param l2_reg_linear: float. L2 regularizer strength applied to linear part.
+    :param l2_reg_dnn: float . L2 regularizer strength applied to DNN
+    :param init_std: float,to use as the initialize std of embedding vector
+    :param seed: integer ,to use as random seed.
+    :param biout_dropout: When not ``None``, the probability we will drop out the output of BiInteractionPooling Layer.
+    :param dnn_dropout: float in [0,1), the probability we will drop out a given DNN coordinate.
+    :param act_func: Activation function to use at prediction layer.
+    :param task: str, ``"binary"`` for  'binary_crossentropy' loss or  ``"multiclass"`` for 'categorical_crossentropy' loss
+    :return: A Keras model instance.
+    """
+    features = build_input_features(feature_columns)
+
+    input_layers = list(features.values())
+    sparse_embedding_list, _ = input_from_feature_columns(features,feature_columns, embedding_size, l2_reg_embedding, init_std, seed)
+
+    fm_input = concat_fun(sparse_embedding_list, axis=1)
+    fm_logit = FM()(fm_input)
+
+    model = tf.keras.models.Model(inputs=input_layers, outputs=fm_logit)
+    return model


### PR DESCRIPTION
* Removed arch's `.fit` method.
* Defined a separate adapter `SklearnTfTransformer` with required methods.
* Adapter's `.fit` now implicitly calls its own `.fit_transform` along the lines of arch object's `.fit` to `.fit_transform` previously; And just returns self. That restrained the call of attributes `sigma` & `vh`, which were previously available right after `.fit`, Instead now it has to be called as `model.fit(x).proxy_model.components_` with current setting.
* Above issue is avoided by using inherited GLM's `.set_params` & `.get_params`, wherein the computed singular values are stored as params in svd class(arch. mod.) at `line#158` & passed back to adapter(adapt. mod.) in `line#67-70`; As a result these values can be as usually accessed as `model.components_` & `model.singular_values_` right after `model.fit`.